### PR TITLE
Added support for customizing infinispan cache configuration

### DIFF
--- a/hibernate-ogm-infinispan7-jpa-example/pom.xml
+++ b/hibernate-ogm-infinispan7-jpa-example/pom.xml
@@ -123,6 +123,22 @@
 		</dependency>
 	</dependencies>
 	<build>
+		<resources>
+			<resource>
+				<directory>src/main/java/</directory>
+				<includes>
+					<include>**/*.xml</include>
+				</includes>
+				<filtering>false</filtering>
+			</resource>
+			<resource>
+				<directory>src/main/resources/</directory>
+				<includes>
+					<include>**/*.xml</include>
+				</includes>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
 		<finalName>hibernate-ogm-infinispan7-jpa-example</finalName>
 		<plugins>
 			<plugin>

--- a/hibernate-ogm-infinispan7-jpa-example/src/main/java/org/hibernate/ogm/infinispan7/jpa/example/dao/infinispan-dist.xml
+++ b/hibernate-ogm-infinispan7-jpa-example/src/main/java/org/hibernate/ogm/infinispan7/jpa/example/dao/infinispan-dist.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The MIT License
+    Copyright (c) 2014 Flemming Harms
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
+-->
+<infinispan
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:infinispan:config:7.0 http://www.infinispan.org/schemas/infinispan-config-7.0.xsd"
+    xmlns="urn:infinispan:config:7.0">
+
+    <jgroups>
+        <!-- This is the default JGroups stack -->
+        <stack-file name="default-udp" path="default-configs/default-jgroups-udp.xml" />
+    </jgroups>
+
+    <cache-container name="HibernateOGM-DIST" default-cache="DEFAULT" statistics="false" shutdown-hook="DONT_REGISTER">
+        <transport stack="default-udp" />
+        <jmx duplicate-domains="true" />
+
+        <distributed-cache name="DEFAULT" mode="SYNC">
+            <locking striping="false" acquire-timeout="10000"
+                concurrency-level="500" write-skew="false" />
+            <transaction mode="NON_DURABLE_XA"
+                transaction-manager-lookup="org.infinispan.transaction.lookup.JBossStandaloneJTAManagerLookup" />
+            <eviction max-entries="-1" strategy="NONE" />
+            <expiration interval="3600000"/>
+            <indexing index="NONE" />
+            <state-transfer enabled="true" timeout="480000"
+                await-initial-transfer="true" />
+        </distributed-cache>
+
+        <distributed-cache name="ENTITIES" mode="SYNC">
+            <locking striping="false" acquire-timeout="10000"
+                concurrency-level="500" write-skew="false" />
+            <transaction mode="NON_DURABLE_XA"
+                transaction-manager-lookup="org.infinispan.transaction.lookup.JBossStandaloneJTAManagerLookup" />
+            <eviction max-entries="-1" strategy="NONE" />
+            <expiration interval="3600000"/>
+            <indexing index="NONE" />
+            <state-transfer enabled="true" timeout="480000"
+                await-initial-transfer="true" />
+        </distributed-cache>
+
+        <distributed-cache name="ASSOCIATIONS" mode="SYNC">
+            <locking striping="false" acquire-timeout="10000"
+                concurrency-level="500" write-skew="false" />
+            <transaction mode="NON_DURABLE_XA"
+                transaction-manager-lookup="org.infinispan.transaction.lookup.JBossStandaloneJTAManagerLookup" />
+            <eviction max-entries="-1" strategy="NONE" />
+            <expiration interval="3600000"/>
+            <indexing index="NONE" />
+            <state-transfer enabled="true" timeout="480000"
+                await-initial-transfer="true" />
+        </distributed-cache>
+
+        <distributed-cache name="IDENTIFIERS" mode="SYNC">
+            <locking striping="false" acquire-timeout="10000"
+                concurrency-level="500" write-skew="false" />
+            <transaction mode="NON_DURABLE_XA"
+                transaction-manager-lookup="org.infinispan.transaction.lookup.JBossStandaloneJTAManagerLookup" />
+            <eviction max-entries="-1" strategy="NONE" />
+            <expiration interval="3600000"/>
+            <indexing index="NONE" />
+            <state-transfer enabled="true" timeout="480000"
+                await-initial-transfer="true" />
+        </distributed-cache>
+
+    </cache-container>
+
+</infinispan>

--- a/hibernate-ogm-infinispan7-jpa-example/src/main/java/org/hibernate/ogm/infinispan7/jpa/example/dao/infinispan-local.xml
+++ b/hibernate-ogm-infinispan7-jpa-example/src/main/java/org/hibernate/ogm/infinispan7/jpa/example/dao/infinispan-local.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The MIT License
+    Copyright (c) 2014 Flemming Harms
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
+-->
+<infinispan
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:infinispan:config:7.0 http://www.infinispan.org/schemas/infinispan-config-7.0.xsd"
+    xmlns="urn:infinispan:config:7.0">
+
+    <cache-container name="HibernateOGM" default-cache="DEFAULT" statistics="false">
+
+        <jmx duplicate-domains="true"/>
+
+        <local-cache name="DEFAULT">
+            <transaction mode="NON_DURABLE_XA" transaction-manager-lookup="org.infinispan.transaction.lookup.JBossStandaloneJTAManagerLookup"/>
+            <expiration interval="3600000"/>
+        </local-cache>
+
+        <local-cache name="ENTITIES">
+            <transaction mode="NON_DURABLE_XA" transaction-manager-lookup="org.infinispan.transaction.lookup.JBossStandaloneJTAManagerLookup"/>
+            <expiration interval="3600000"/>
+        </local-cache>
+
+        <local-cache name="ASSOCIATIONS">
+            <transaction mode="NON_DURABLE_XA" transaction-manager-lookup="org.infinispan.transaction.lookup.JBossStandaloneJTAManagerLookup"/>
+            <expiration interval="3600000"/>
+        </local-cache>
+
+        <local-cache name="IDENTIFIERS">
+            <transaction mode="NON_DURABLE_XA" transaction-manager-lookup="org.infinispan.transaction.lookup.JBossStandaloneJTAManagerLookup"/>
+            <expiration interval="-1"/>
+        </local-cache>
+
+    </cache-container>
+</infinispan>

--- a/hibernate-ogm-infinispan7-jpa-example/src/main/resources/META-INF/persistence.xml
+++ b/hibernate-ogm-infinispan7-jpa-example/src/main/resources/META-INF/persistence.xml
@@ -6,10 +6,14 @@
         <class>org.hibernate.ogm.infinispan7.jpa.example.model.Subscriber</class>
         <class>org.hibernate.ogm.infinispan7.jpa.example.model.EventVO</class>
         <properties>
+        	<!-- Changing from filebase to Infinispan gave huge performance from 3 sec to 177 ms -->
+        	<property name="hibernate.search.default.directory_provider" value="infinispan"/> 
+        	<property name="hibernate.search.default.exclusive_index_use" value="false"/>
             <property name="hibernate.transaction.jta.platform"
                       value="org.hibernate.service.jta.platform.internal.JBossAppServerJtaPlatform" />
              <property name="hibernate.ogm.datastore.provider"
                       value="infinispan" />
+             <property name="hibernate.ogm.infinispan.configuration_resource_name" value="org/hibernate/ogm/infinispan7/jpa/example/dao/infinispan-local.xml"/>
           </properties>
     </persistence-unit>
 </persistence>

--- a/hibernate-ogm-infinispan7-jpa-example/src/test/java/org/hibernate/ogm/infinispan7/jpa/example/dao/RemoteEventDaoIT.java
+++ b/hibernate-ogm-infinispan7-jpa-example/src/test/java/org/hibernate/ogm/infinispan7/jpa/example/dao/RemoteEventDaoIT.java
@@ -56,13 +56,16 @@ public class RemoteEventDaoIT {
     public static WebArchive createDeployment() {
         WebArchive webArchive = ShrinkWrap
                 .create(WebArchive.class)
-                .addClass(RemoteEventDao.class)
                 .addPackage("org.hibernate.ogm.infinispan7.jpa.example.model")
+                .addPackage("org.hibernate.ogm.infinispan7.jpa.example.dao")
+                .addAsResource("org/hibernate/ogm/infinispan7/jpa/example/dao/infinispan-local.xml", "org/hibernate/ogm/infinispan7/jpa/example/dao/infinispan-local.xml")
+                .addAsResource("org/hibernate/ogm/infinispan7/jpa/example/dao/infinispan-dist.xml", "org/hibernate/ogm/infinispan7/jpa/example/dao/infinispan-dist.xml")
                 .addAsResource("META-INF/persistence.xml", "META-INF/persistence.xml")
                 .setManifest(
                         new StringAsset(
                                 "Dependencies: org.hibernate:ogm services, org.hibernate.ogm.infinispan services, org.hibernate.search.orm:5.1 services"))
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        System.out.println("Jar :"+webArchive.toString(true));
         return webArchive;
     }
 
@@ -134,7 +137,7 @@ public class RemoteEventDaoIT {
             EventVO entity = createTestEvent(String.format("My #%s event", i), EventType.UPDATE);
             remoteEventDAO.addEvent(entity);
         }
-        System.out.print(String.format("Time to publish : %s sec",(System.currentTimeMillis()- startTime)/1000));
+        System.out.print(String.format("Time to publish : %s ms",(System.currentTimeMillis()- startTime)));
         
         for (String string : clientIds) {
             List<RemoteEvent> eventsForClientId = remoteEventDAO.retreiveEventsForClientId(string);
@@ -157,7 +160,7 @@ public class RemoteEventDaoIT {
         EventVO entity = createTestEvent(String.format("My #%s event", 1), EventType.UPDATE);
         long startTime = System.currentTimeMillis();
         remoteEventDAO.addEvent(entity,clientIds);
-        System.out.print(String.format("Time to publish : %s sec",(System.currentTimeMillis()- startTime)/1000));
+        System.out.print(String.format("Time to publish : %s ms",(System.currentTimeMillis()- startTime)));
         
         for (String clientId : clientIds) {
             List<RemoteEvent> eventsForClientId = remoteEventDAO.retreiveEventsForClientId(clientId);

--- a/hibernate-ogm-infinispan7-jpa-example/src/test/resources/arquillian.xml
+++ b/hibernate-ogm-infinispan7-jpa-example/src/test/resources/arquillian.xml
@@ -5,11 +5,11 @@
        <property name="executionType">REMOTE</property>
     </protocol>
     <configuration>
-      <property name="outputToConsole">true</property>
+      <property name="outputToConsole">false</property>
       <property name="jbossHome">${jboss.home}</property>
       <property name="allowConnectingToRunningServer">false</property>
       <!--  -XX:MaxPermSize=768m -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n -->
-      <property name="javaVmArguments">-Darquillian.debug=true -Djava.net.preferIPv4Stack=true -Xms1024m -Xmx2048m</property>
+      <property name="javaVmArguments">-Darquillian.debug=true -Djava.net.preferIPv4Stack=true -Xms512m -Xmx1024m -XX:MaxPermSize=768m</property>
     </configuration>
   </container>
 </arquillian>


### PR DESCRIPTION
2 files is placed in the "org/hibernate/ogm/infinispan7/jpa/example/dao/", one
for local cache and one for a distributed cache configuration. In the persistence.xml
you can switch between the 2 configurations.

Changed Hibernate Search provider to Infinispan

Changed the search provider from file system to Infinispan gave a hugh performance
boost because the indexes is now stored in memory
